### PR TITLE
Refactor: Remove email addresses and update styling

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -42,16 +42,7 @@
        
           <section class="mt-3 mr-3 ml-3 pl-5 pr-5 pb-4 justify-center items-center flex flex-col" id="connect">
             <h2 class="mb-5 whitespace-nowrap sm:text-3xl text-xl font-bold">Let's Connect</h2>
-            <ul class="mt-6 mb-10 flex fex-row content-between">
-              <li>
-                <a href="mailto: shamala.mallya@outlook.com"
-                  ><img
-                    src="./img/icons8-mail-48.png"
-                    alt="email"
-                    height="48"
-                    width="48"
-                /></a>
-              </li>
+            <ul class="mt-6 mb-10 flex fex-row justify-center space-x-6">
               <li class="text-center">
                 <a href="https://www.linkedin.com/in/b-shamala-mallya/"
                   ><img

--- a/build/resume.html
+++ b/build/resume.html
@@ -26,13 +26,9 @@
               <dl class="p-2 mb-10">
                 <dt class="font-bold text-lg mt-3">Address</dt>
                 <dd>Cupertino, CA 95014</dd>
-                <dt class="font-bold text-lg mt-3">E-mail</dt>
-                <dd>shamala.mallya@outlook.com</dd>
-                <dt class="font-bold text-lg mt-3">Secondary E-mail</dt>
-                <dd>msurabhi23@gmail.com</dd>
                 <dt class="font-bold text-lg mt-3">LinkedIn</dt>
                 <dd><a href="https://www.linkedin.com/in/b-shamala-mallya">https://www.linkedin.com/in/b-shamala-mallya</a></dd>
-              </dd>
+              </dl>
           </section>
           <section>
             <h2 class="text-center font-bold bg-teal-900 text-xl sm:text-2xl text-white">Skills</h2>


### PR DESCRIPTION
I've removed the email contact information from your website as you requested.

- In `index.html`:
    - I removed the mail icon and associated email link from the "Let's Connect" section.
    - I adjusted Tailwind CSS classes for the social media icon list to ensure proper alignment and spacing after removal. I changed `content-between` to `justify-center space-x-6` on the parent `ul`.

- In `resume.html`:
    - I removed the "E-mail" and "Secondary E-mail" fields from the "Contact" section.
    - I corrected a minor HTML typo (closing `</dd>` to `</dl>`).

These changes ensure that the specified email addresses are no longer publicly visible on the site and that the layout remains consistent.